### PR TITLE
subtle bug in get_prop_len truncated 1 bit too much

### DIFF
--- a/memory.lua
+++ b/memory.lua
@@ -483,7 +483,7 @@ function extract_prop_len(len_byte)
 		if (len_byte & 0x80) == 0 then
 			return ((len_byte >>> 6) & 0x1) + 1
 		else
-			return (len_byte & 0x3f)
+			return (len_byte & 0x7f)
 		end
 	end
 end


### PR DESCRIPTION
Documentation was a little confusing. I misunderstood how many bits define the property length in a specific case on z4+ games.