### PR TITLE
Bug/load new game

### DIFF
--- a/io.lua
+++ b/io.lua
@@ -1,50 +1,7 @@
--- current_bg = 0
--- current_fg = 1
--- current_font = 1
-
--- current_format = ''
--- current_format_updated = false
--- window_attributes = 0b00000000.00001010
-
--- --io control
--- emit_rate = 0 --the lower the faster
--- clock_type = nil
--- cursor_type = nil
--- make_bold = false
--- make_inverse = true
-
--- screen_output = true
--- memory_output = {}
-
--- --0-indexed windows to match z-machine index usage
--- active_window = nil
--- windows = {
--- 	[0] = {
--- 		y = 1, -- x is ALWAYS 1
--- 		h = 21, -- w is ALWAYS 32
--- 		z_cursor = {x=1,y=21}, --formerly cur_x, cur_y
--- 		p_cursor = {0,0}, -- unnamed vars for unpack()ing
--- 		screen_rect = {},
--- 		buffer = {},
--- 		last_line = ''
--- 	},
--- 	{
--- 		y = 1,
--- 		h = 0,
--- 		z_cursor = {x=1,y=1},
--- 		p_cursor = {0,0},
--- 		screen_rect = {},
--- 		buffer = {}
--- 	}
--- }
-
 function reset_screen_state()
 	current_bg = 0
 	current_fg = 1
 	current_font = 1
-
-	current_format = ''
-	current_format_updated = false
 
 	current_format = ''
 	current_format_updated = false

--- a/io.lua
+++ b/io.lua
@@ -1,43 +1,85 @@
-current_bg = 0
-current_fg = 1
-current_font = 1
+-- current_bg = 0
+-- current_fg = 1
+-- current_font = 1
 
-previous_format = ''
-current_format = ''
-current_format_updated = false
-window_attributes = 0b00000000.00001010
+-- current_format = ''
+-- current_format_updated = false
+-- window_attributes = 0b00000000.00001010
 
---io control
-emit_rate = 0 --the lower the faster
-clock_type = nil
-cursor_type = nil
-make_bold = false
-make_inverse = true
+-- --io control
+-- emit_rate = 0 --the lower the faster
+-- clock_type = nil
+-- cursor_type = nil
+-- make_bold = false
+-- make_inverse = true
 
-screen_output = true
-memory_output = {}
+-- screen_output = true
+-- memory_output = {}
 
---0-indexed windows to match z-machine index usage
-active_window = nil
-windows = {
-	[0] = {
-		y = 1, -- x is ALWAYS 1
-		h = 21, -- w is ALWAYS 32
-		z_cursor = {x=1,y=21}, --formerly cur_x, cur_y
-		p_cursor = {0,0}, -- unnamed vars for unpack()ing
-		screen_rect = {},
-		buffer = {},
-		last_line = ''
-	},
-	{
-		y = 1,
-		h = 0,
-		z_cursor = {x=1,y=1},
-		p_cursor = {0,0},
-		screen_rect = {},
-		buffer = {}
+-- --0-indexed windows to match z-machine index usage
+-- active_window = nil
+-- windows = {
+-- 	[0] = {
+-- 		y = 1, -- x is ALWAYS 1
+-- 		h = 21, -- w is ALWAYS 32
+-- 		z_cursor = {x=1,y=21}, --formerly cur_x, cur_y
+-- 		p_cursor = {0,0}, -- unnamed vars for unpack()ing
+-- 		screen_rect = {},
+-- 		buffer = {},
+-- 		last_line = ''
+-- 	},
+-- 	{
+-- 		y = 1,
+-- 		h = 0,
+-- 		z_cursor = {x=1,y=1},
+-- 		p_cursor = {0,0},
+-- 		screen_rect = {},
+-- 		buffer = {}
+-- 	}
+-- }
+
+function reset_screen_state()
+	current_bg = 0
+	current_fg = 1
+	current_font = 1
+
+	current_format = ''
+	current_format_updated = false
+
+	current_format = ''
+	current_format_updated = false
+	window_attributes = 0b00000000.00001010
+
+	emit_rate = 0 --the lower the faster
+	clock_type = nil
+	cursor_type = nil
+	make_bold = false
+	make_inverse = true
+
+	screen_output = true
+	memory_output = {}
+
+	active_window = 0
+	windows = {
+		[0] = {
+			y = 1, -- x is ALWAYS 1
+			h = 21, -- w is ALWAYS 32
+			z_cursor = {x=1,y=21}, --formerly cur_x, cur_y
+			p_cursor = {0,0}, -- unnamed vars for unpack()ing
+			screen_rect = {},
+			buffer = {},
+			last_line = ''
+		},
+		{
+			y = 1,
+			h = 0,
+			z_cursor = {x=1,y=1},
+			p_cursor = {0,0},
+			screen_rect = {},
+			buffer = {}
+		}
 	}
-}
+end
 
 function update_current_format(n)
 	local inverse, emphasis = '\^-i\^-b', '\015'
@@ -140,7 +182,6 @@ function output(str, flush_now)
 
 			-- log('considering char: '..char)
 			if current_format_updated == true then
-				previous_format = current_format
 				current_line ..= current_format
 				current_format_updated = false
 			end

--- a/memory.lua
+++ b/memory.lua
@@ -35,19 +35,19 @@ interpreter_version = 0x.001f
 _screen_height = 0x.0020 --lines
 _screen_width = 0x.0021 --characters
 
-active_table = 1
+-- active_table = 1
 
 bank_size = 16384 -- (1024*64)/4; four 64K banks
-_memory = {{}}
+-- _memory = {{}}
 --call stack holds a flat list of frame data
 --a frame consists of 10 numbers:
 --   stack pointer, program counter, 8 zwords for in-scope local vars
-_call_stack = {}
-_stack = {}
+-- _call_stack = {}
+-- _stack = {}
 
 --these copies are used to grab a save state snapshot
-_memory_start_state = nil
-_current_state = ''
+-- _memory_start_state = nil
+-- _current_state = ''
 
 --we can't reset all memory otherwise the player
 --would have to drag the z3 game file in again
@@ -73,6 +73,7 @@ function flush_volatile_state()
 	_stack = {}
 	_program_counter = 0x0
 	_interrupt = nil
+	_current_state = ''
 	active_table = 1
 	max_input_length = 0
 	z_parse_buffer_length = 0

--- a/memory.lua
+++ b/memory.lua
@@ -35,19 +35,7 @@ interpreter_version = 0x.001f
 _screen_height = 0x.0020 --lines
 _screen_width = 0x.0021 --characters
 
--- active_table = 1
-
 bank_size = 16384 -- (1024*64)/4; four 64K banks
--- _memory = {{}}
---call stack holds a flat list of frame data
---a frame consists of 10 numbers:
---   stack pointer, program counter, 8 zwords for in-scope local vars
--- _call_stack = {}
--- _stack = {}
-
---these copies are used to grab a save state snapshot
--- _memory_start_state = nil
--- _current_state = ''
 
 --we can't reset all memory otherwise the player
 --would have to drag the z3 game file in again
@@ -69,6 +57,9 @@ function clear_all_memory()
 end
 
 function flush_volatile_state()
+	--call stack holds a flat list of frame data
+	--a frame consists of 10 numbers:
+	--   stack pointer, program counter, 8 zwords for in-scope local vars
 	_call_stack = {}
 	_stack = {}
 	_program_counter = 0x0

--- a/memory.lua
+++ b/memory.lua
@@ -51,29 +51,31 @@ _current_state = ''
 
 --we can't reset all memory otherwise the player
 --would have to drag the z3 game file in again
-function reset_game()
+function reset_session()
 	for i = 1, #_memory_start_state do
 		local bank = _memory_start_state[i]
 		for j = 1, #bank do
 			_memory[i][j] = _memory_start_state[i][j]
 		end
 	end
-	_call_stack = {}
-	_stack = {}
-	_program_counter = 0x0
-	_interrupt = nil
-	story_loaded = false
+	flush_volatile_state()
 	initialize_game()
 end
 
-function reset_all_memory()
+function clear_all_memory()
 	_memory = {{}}
+	_memory_start_state = nil
+	flush_volatile_state()
+end
+
+function flush_volatile_state()
 	_call_stack = {}
 	_stack = {}
 	_program_counter = 0x0
 	_interrupt = nil
+	active_table = 1
 	max_input_length = 0
-	parse_buffer_length = 0
+	z_parse_buffer_length = 0
 	separators = {}
 	_dictionary_lookup = {}
 	story_loaded = false
@@ -786,6 +788,7 @@ function capture_state(state)
 end
 
 function load_story_file()
+	clear_all_memory()
 	while stat(120) do
 		if (#_memory[#_memory] == bank_size) add(_memory, {})
 		local bank_num = #_memory

--- a/ops.lua
+++ b/ops.lua
@@ -351,7 +351,7 @@ function restore()
 end
 function restart()
 	--log('restart: ')
-	reset_game()
+	reset_session()
 end
 function ret_popped()
 	--log('ret_popped: ')

--- a/status_line.p8
+++ b/status_line.p8
@@ -293,18 +293,18 @@ end
 function process_header()
 	_z_machine_version = get_zbyte(version)
 
+	screen_height = 21
+	packed_shift = 2
+	default_property_count = 63
+	object_entry_size = 0x.000e
+	dictionary_word_size = 9
+	
 	if _z_machine_version == 3 then
 		screen_height = 20
 		packed_shift = 1
 		default_property_count = 31
 		object_entry_size = 0x.0009
 		dictionary_word_size = 6
-	else
-		screen_height = 21
-		packed_shift = 2
-		default_property_count = 63
-		object_entry_size = 0x.000e
-		dictionary_word_size = 9
 	end
 
 	set_zbyte(_screen_height, screen_height)

--- a/status_line.p8
+++ b/status_line.p8
@@ -293,18 +293,19 @@ end
 function process_header()
 	_z_machine_version = get_zbyte(version)
 
-	screen_height = 21
-	packed_shift = 2
-	default_property_count = 63
-	object_entry_size = 0x.000e
-	dictionary_word_size = 9
 	
-	if _z_machine_version == 3 then
+	if _z_machine_version < 4 then
 		screen_height = 20
 		packed_shift = 1
 		default_property_count = 31
 		object_entry_size = 0x.0009
 		dictionary_word_size = 6
+	else 
+		screen_height = 21
+		packed_shift = 2
+		default_property_count = 63
+		object_entry_size = 0x.000e
+		dictionary_word_size = 9
 	end
 
 	set_zbyte(_screen_height, screen_height)
@@ -330,16 +331,16 @@ function process_header()
 end
 
 function cache_memory_addresses()
-	_program_counter = zword_to_zaddress(get_zword(program_counter_addr))
-	_paged_memory_addr = zword_to_zaddress(get_zword(paged_memory_addr))
-	_dictionary_addr = zword_to_zaddress(get_zword(dictionary_addr))
-	_object_table_addr = zword_to_zaddress(get_zword(object_table_addr))
+	_program_counter 	= zword_to_zaddress(get_zword(program_counter_addr))
+	_paged_memory_addr 	= zword_to_zaddress(get_zword(paged_memory_addr))
+	_dictionary_addr 	= zword_to_zaddress(get_zword(dictionary_addr))
+	_object_table_addr 	= zword_to_zaddress(get_zword(object_table_addr))
 	_global_var_table_addr = zword_to_zaddress(get_zword(global_var_table_addr))
-	_abbr_table_addr = zword_to_zaddress(get_zword(abbr_table_addr))
-	_static_mem_addr = zword_to_zaddress(get_zword(static_mem_addr))
+	_abbr_table_addr 	= zword_to_zaddress(get_zword(abbr_table_addr))
+	_static_mem_addr 	= zword_to_zaddress(get_zword(static_mem_addr))
 end
 
-function patch()
+function patch() --override screen-width checks on some games
 	checksum = get_zword(file_checksum)
 	-- log('checksum: '..tohex(checksum))
 	if (checksum == 0x16ab) set_zbyte(0x.fddd,1) --trinity, thanks @fredrick

--- a/status_line.p8
+++ b/status_line.p8
@@ -42,19 +42,19 @@ local cursor_types = {
 	}
 }
 
---frequently used values we can cache before starting
-max_input_length = 0
-z_parse_buffer_length = 0
-separators = {}
-_dictionary_lookup = {}
+-- --frequently used values we can cache before starting
+-- max_input_length = 0
+-- z_parse_buffer_length = 0
+-- separators = {}
+-- _dictionary_lookup = {}
 blank_line = '                                '
 
---default these to z4+ specs
-screen_height = 21
-packed_shift = 2
-default_property_count = 63
-object_entry_size = 0x.000e
-dictionary_word_size = 9
+-- --default these to z4+ specs
+-- screen_height = 21
+-- packed_shift = 2
+-- default_property_count = 63
+-- object_entry_size = 0x.000e
+-- dictionary_word_size = 9
 
 --these literally make the engine run
 _program_counter = 0x0
@@ -189,6 +189,7 @@ function game_id()
 end
 
 function setup_palette()
+	pal()
 	local st = dget(0) or 1
 	local type = screen_types.values[st]
 	full_color = type[1] == 'ega'
@@ -245,7 +246,7 @@ function _update60()
 				flush_line_buffer()
 				screen("\^i\#0\f1       ~ END OF SESSION ~       ")
 				wait_for_any_key()
-				reset_all_memory()
+				clear_all_memory()
 			end
 			pal()
 			draw_splashscreen(false)
@@ -298,6 +299,12 @@ function process_header()
 		default_property_count = 31
 		object_entry_size = 0x.0009
 		dictionary_word_size = 6
+	else
+		screen_height = 21
+		packed_shift = 2
+		default_property_count = 63
+		object_entry_size = 0x.000e
+		dictionary_word_size = 9
 	end
 
 	set_zbyte(_screen_height, screen_height)
@@ -341,6 +348,8 @@ end
 
 function initialize_game()
 
+	reset_screen_state()
+
 	setup_user_prefs()
 	setup_palette()
 	process_header()
@@ -354,9 +363,8 @@ function initialize_game()
 	--special case at startup for the program counter
 	_call_stack[#_call_stack - 9] = _program_counter
 
-	active_window = 0
-	split_window(0)
 	if (_memory_start_state == nil) capture_state(_memory_start_state)
+	split_window(0)
 	update_current_format(0)
 	update_p_cursor()
 	story_loaded = true

--- a/status_line.p8
+++ b/status_line.p8
@@ -10,7 +10,8 @@ checksum = 0x0
 story_loaded = false
 -- full_color = false
 
-local punc = '.,!?_#'.."'"..'"/\\-:()'
+punc = '.,!?_#'.."'"..'"/\\-:()'
+blank_line = '                                '
 
 local screen_types = {
 	default = 1, 
@@ -42,24 +43,9 @@ local cursor_types = {
 	}
 }
 
--- --frequently used values we can cache before starting
--- max_input_length = 0
--- z_parse_buffer_length = 0
--- separators = {}
--- _dictionary_lookup = {}
-blank_line = '                                '
-
--- --default these to z4+ specs
--- screen_height = 21
--- packed_shift = 2
--- default_property_count = 63
--- object_entry_size = 0x.000e
--- dictionary_word_size = 9
-
 --these literally make the engine run
 _program_counter = 0x0
 _interrupt = nil
-
 
 --useful functions
 function in_set(val, set)
@@ -293,7 +279,6 @@ end
 function process_header()
 	_z_machine_version = get_zbyte(version)
 
-	
 	if _z_machine_version < 4 then
 		screen_height = 20
 		packed_shift = 1


### PR DESCRIPTION
Ran some simple tests of this branch behavior against original.
This seems to be working well; no garbage or crashing when switching games from z3 to z4 and back again.
Not entirely certain how to test this with 100% certainty. If there are any major problems with how this is handling things, that will probably come out during the normal deep testing process (to come later). 

But right now:
- Current version: crash when switching from v3 to v4 game
  - load z3 game -> "quit" -> back at splashscreen load z4 -> crash)
- This version: the above problem does not exist (but I suppose something could reveal itself if we do long playtests then switch and do another LOOONG playtest, and load in saved games, and really push things)