### PR TITLE
Save and Restore Fixed

### DIFF
--- a/io.lua
+++ b/io.lua
@@ -502,18 +502,19 @@ function restore_game()
 		for j = 1, stack_length do
 			add(frame.stack, temp[offset + 4 + j])
 		end
+		offset += 4 + stack_length
 		for k = 1, 16 do
-			add(frame.vars, temp[offset + stack_length + k])
+			add(frame.vars, temp[offset + k])
 		end
 		add(_call_stack, frame)
-		offset += stack_length + 21 --20 steps are fixed, # of stack items is variable, +1 to get to NEXT item
+		offset += 16
+		log("restoring frame "..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args)..', '..tohex(#frame.stack)..','..tohex(frame.vars[1]))
 	end
 
-	-- log('setting pc to: '..tohex(temp[#temp-1], true))
-	-- _program_counter = temp[#temp-1]
-	call_stack_pop()
+	_program_counter = temp[#temp-1]
+	log('restoring pc: '..tohex(_program_counter, true))
 	current_input = ''
-	process_header()
+	-- process_header()
 	return (_zm_version == 3) and true or 2
 end
 

--- a/io.lua
+++ b/io.lua
@@ -473,10 +473,7 @@ function restore_game()
 	offset += 1
 	local memory_length = temp[offset]
 	local mem_max_bank, mem_max_index, _ = get_memory_location( _static_memory_mem_addr - 0x.0001)
-	-- assert(memory_length == mem_max_bank*mem_max_index, "Misaligned memory in save file?")
-	-- local mem_max_bank = (memory_length\_memory_bank_size)+1
-	-- local mem_max_index = memory_length - ((mem_max_bank-1)*_memory_bank_size)
-	log('memory_length ('..mem_max_bank..','..mem_max_index..'): '..memory_length)
+	-- log('memory_length ('..mem_max_bank..','..mem_max_index..'): '..memory_length)
 	local temp_index = 1
 	for i = 1, mem_max_bank do
 		local max_j = _memory_bank_size
@@ -498,23 +495,28 @@ function restore_game()
 		frame.pc = temp[offset + 1]
 		frame.call = temp[offset + 2]
 		frame.args = temp[offset + 3]
+		-- log("restoring frame "..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args))
 		local stack_length = temp[offset + 4]
+		-- log("---frame stack---")
 		for j = 1, stack_length do
-			add(frame.stack, temp[offset + 4 + j])
+			local val = temp[offset + 4 + j]
+			add(frame.stack, val)
+			-- log("  "..j..': '..tohex(temp[offset + 4 + j])..' -> '..tohex(frame.stack[j]))
 		end
 		offset += 4 + stack_length
+		-- log("---frame vars---")
 		for k = 1, 16 do
-			add(frame.vars, temp[offset + k])
+			local val = temp[offset + k]
+			frame.vars[k] =  val
+			-- log("  "..k..": "..tohex(temp[offset + k])..' -> '..tohex(frame.vars[k]))
 		end
 		add(_call_stack, frame)
 		offset += 16
-		log("restoring frame "..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args)..', '..tohex(#frame.stack)..','..tohex(frame.vars[1]))
 	end
 
 	_program_counter = temp[#temp-1]
-	log('restoring pc: '..tohex(_program_counter, true))
+	-- log('restoring pc: '..tohex(_program_counter, true))
 	current_input = ''
-	-- process_header()
 	return (_zm_version == 3) and true or 2
 end
 

--- a/memory.lua
+++ b/memory.lua
@@ -776,7 +776,7 @@ function capture_state(state)
 				end			
 			end
 		end
-		log("after memory_start_state with bank "..mem_max_bank..": "..stat(0))
+		-- log("after memory_start_state with bank "..mem_max_bank..": "..stat(0))
 	else
 
 		local memory_dump = dword_to_str(tonum(_engine_version))
@@ -798,19 +798,23 @@ function capture_state(state)
 			memory_dump ..= dword_to_str(frame.pc)
 			memory_dump ..= dword_to_str(frame.call)
 			memory_dump ..= dword_to_str(frame.args)
+			-- log("saving frame"..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args))
 			--save local stack size and values
 			memory_dump ..= dword_to_str(#frame.stack)
-			for i = 1, #frame.stack do
-				memory_dump ..= dword_to_str(frame.stack[i])
+			-- log("---frame stack---")
+			for j = 1, #frame.stack do
+				memory_dump ..= dword_to_str(frame.stack[j])
+				-- log("  "..j..': '..tohex(frame.stack[j])..' -> '..dword_to_str(frame.stack[j]))
 			end
 			--save local vars (always 16)
-			for i = 1, 16 do
-				memory_dump ..= dword_to_str(frame.vars[i])
+			-- log("---frame vars---")
+			for k = 1, 16 do
+				memory_dump ..= dword_to_str(frame.vars[k])
+				-- log("  "..k..": "..tohex(frame.vars[k])..' -> '..dword_to_str(frame.vars[k]))
 			end
-			log("saving frame"..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args)..', '..tohex(#frame.stack)..','..tohex(frame.vars[1]))
 		end
 
-		log('saving pc: '..(tohex(_program_counter,true)))
+		-- log('saving pc: '..(tohex(_program_counter,true)))
 		memory_dump ..= dword_to_str(_program_counter)
 		memory_dump ..= dword_to_str(checksum)
 

--- a/memory.lua
+++ b/memory.lua
@@ -807,6 +807,7 @@ function capture_state(state)
 			for i = 1, 16 do
 				memory_dump ..= dword_to_str(frame.vars[i])
 			end
+			log("saving frame"..i..": "..tohex(frame.pc)..', '..tohex(frame.call)..', '..tohex(frame.args)..', '..tohex(#frame.stack)..','..tohex(frame.vars[1]))
 		end
 
 		log('saving pc: '..(tohex(_program_counter,true)))

--- a/memory.lua
+++ b/memory.lua
@@ -60,7 +60,7 @@ _memory_bank_size = 16384 -- (1024*64)/4; four 64K banks
 call_type = { none = 0, func = 1, proc = 2, intr = 3 }
 
 -- frame prototype: program_counter, call_type, num_args
-frame = { pc = 0, call = nil, args = 0 }
+frame = { pc = 0, call = 0, args = 0 }
 
 function frame:new()
  local obj = {
@@ -804,12 +804,12 @@ function capture_state(state)
 				memory_dump ..= dword_to_str(frame.stack[i])
 			end
 			--save local vars (always 16)
-			for i = 1, #frame.vars do
+			for i = 1, 16 do
 				memory_dump ..= dword_to_str(frame.vars[i])
 			end
 		end
 
-		-- log('saving pc: '..(tohex(_program_counter,true)))
+		log('saving pc: '..(tohex(_program_counter,true)))
 		memory_dump ..= dword_to_str(_program_counter)
 		memory_dump ..= dword_to_str(checksum)
 


### PR DESCRIPTION
New definition of a "frame" on the call stack means we need a new way to save/restore state.
This does, unfortunately, break save file compatibility with previous versions of Status Line.
That just can't be helped because z5 and higher include frame information that we didn't need for z3 and z4.